### PR TITLE
Update node.js http server

### DIFF
--- a/servers/nodejs_http_server.js
+++ b/servers/nodejs_http_server.js
@@ -10,10 +10,13 @@ function handle(request, response) {
     if (!msize) {
         msize = 1024;
     } else {
-        msize = parseInt(msize);
+        msize = parseInt(msize, 10);
     }
     if (!responses[msize]) {
-        responses[msize] = Array(msize).join("X");
+	// for Node.js v4
+	responses[msize] = new Buffer(msize).fill("X");
+	// for Node.js v6
+	// responses[msize] = Buffer.alloc(msize, "X");
     }
     response.end(responses[msize]);
 }


### PR DESCRIPTION
Refactoring code to more node.js-like way:
- use new Buffer with fill() instead of Array with join (Buffer.alloc for Node.js v6)
- parseInt() with radix

I haven't run benchmarks yet, but this changes can have some impact on perfomance.
