### PR TITLE
Variable name is not correct.

### DIFF
--- a/servers/asyncioecho.py
+++ b/servers/asyncioecho.py
@@ -31,7 +31,7 @@ async def echo_server(loop, address, unix):
 
 async def echo_client(loop, client):
     try:
-        sock.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+        client.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
     except (OSError, NameError):
         pass
 


### PR DESCRIPTION
This might be causing NameErrors more frequently than the sockopt() should be.
